### PR TITLE
fix(spec): priority, weight and port should be string, not integer

### DIFF
--- a/api/v0/domeneshop/api/openapi.yaml
+++ b/api/v0/domeneshop/api/openapi.yaml
@@ -877,9 +877,8 @@ components:
         priority:
           description: MX record priority, also known as preference. Lower values
             are usually preferred first, but this is not guaranteed
-          example: 1
-          format: int16
-          type: integer
+          example: "1"
+          type: string
       required:
       - data
       - priority
@@ -899,19 +898,16 @@ components:
         priority:
           description: SRV record priority, also known as preference. Lower values
             are usually preferred first
-          example: 10
-          format: int16
-          type: integer
+          example: "10"
+          type: string
         weight:
           description: SRV record weight. Relevant if multiple records have same preference
-          example: 100
-          format: int16
-          type: integer
+          example: "100"
+          type: string
         port:
           description: SRV record port. The port where the service is found.
-          example: 443
-          format: int16
-          type: integer
+          example: "443"
+          type: string
       required:
       - data
       - port

--- a/api/v0/domeneshop/docs/DNSRecord.md
+++ b/api/v0/domeneshop/docs/DNSRecord.md
@@ -9,15 +9,15 @@ Name | Type | Description | Notes
 **Ttl** | Pointer to **int32** | TTL of DNS record in seconds. Must be a multiple of 60. | [optional] [default to 3600]
 **Type** | **string** |  | 
 **Data** | **string** | Freeform text field. | 
-**Priority** | **int32** | SRV record priority, also known as preference. Lower values are usually preferred first | 
-**Weight** | **int32** | SRV record weight. Relevant if multiple records have same preference | 
-**Port** | **int32** | SRV record port. The port where the service is found. | 
+**Priority** | **string** | SRV record priority, also known as preference. Lower values are usually preferred first | 
+**Weight** | **string** | SRV record weight. Relevant if multiple records have same preference | 
+**Port** | **string** | SRV record port. The port where the service is found. | 
 
 ## Methods
 
 ### NewDNSRecord
 
-`func NewDNSRecord(id int32, host string, type_ string, data string, priority int32, weight int32, port int32, ) *DNSRecord`
+`func NewDNSRecord(id int32, host string, type_ string, data string, priority string, weight string, port string, ) *DNSRecord`
 
 NewDNSRecord instantiates a new DNSRecord object
 This constructor will assign default values to properties that have it defined,
@@ -139,60 +139,60 @@ SetData sets Data field to given value.
 
 ### GetPriority
 
-`func (o *DNSRecord) GetPriority() int32`
+`func (o *DNSRecord) GetPriority() string`
 
 GetPriority returns the Priority field if non-nil, zero value otherwise.
 
 ### GetPriorityOk
 
-`func (o *DNSRecord) GetPriorityOk() (*int32, bool)`
+`func (o *DNSRecord) GetPriorityOk() (*string, bool)`
 
 GetPriorityOk returns a tuple with the Priority field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPriority
 
-`func (o *DNSRecord) SetPriority(v int32)`
+`func (o *DNSRecord) SetPriority(v string)`
 
 SetPriority sets Priority field to given value.
 
 
 ### GetWeight
 
-`func (o *DNSRecord) GetWeight() int32`
+`func (o *DNSRecord) GetWeight() string`
 
 GetWeight returns the Weight field if non-nil, zero value otherwise.
 
 ### GetWeightOk
 
-`func (o *DNSRecord) GetWeightOk() (*int32, bool)`
+`func (o *DNSRecord) GetWeightOk() (*string, bool)`
 
 GetWeightOk returns a tuple with the Weight field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetWeight
 
-`func (o *DNSRecord) SetWeight(v int32)`
+`func (o *DNSRecord) SetWeight(v string)`
 
 SetWeight sets Weight field to given value.
 
 
 ### GetPort
 
-`func (o *DNSRecord) GetPort() int32`
+`func (o *DNSRecord) GetPort() string`
 
 GetPort returns the Port field if non-nil, zero value otherwise.
 
 ### GetPortOk
 
-`func (o *DNSRecord) GetPortOk() (*int32, bool)`
+`func (o *DNSRecord) GetPortOk() (*string, bool)`
 
 GetPortOk returns a tuple with the Port field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPort
 
-`func (o *DNSRecord) SetPort(v int32)`
+`func (o *DNSRecord) SetPort(v string)`
 
 SetPort sets Port field to given value.
 

--- a/api/v0/domeneshop/docs/MX.md
+++ b/api/v0/domeneshop/docs/MX.md
@@ -9,13 +9,13 @@ Name | Type | Description | Notes
 **Ttl** | Pointer to **int32** | TTL of DNS record in seconds. Must be a multiple of 60. | [optional] [default to 3600]
 **Type** | **string** |  | 
 **Data** | **string** | The target MX host. | 
-**Priority** | **int32** | MX record priority, also known as preference. Lower values are usually preferred first, but this is not guaranteed | 
+**Priority** | **string** | MX record priority, also known as preference. Lower values are usually preferred first, but this is not guaranteed | 
 
 ## Methods
 
 ### NewMX
 
-`func NewMX(id int32, host string, type_ string, data string, priority int32, ) *MX`
+`func NewMX(id int32, host string, type_ string, data string, priority string, ) *MX`
 
 NewMX instantiates a new MX object
 This constructor will assign default values to properties that have it defined,
@@ -137,20 +137,20 @@ SetData sets Data field to given value.
 
 ### GetPriority
 
-`func (o *MX) GetPriority() int32`
+`func (o *MX) GetPriority() string`
 
 GetPriority returns the Priority field if non-nil, zero value otherwise.
 
 ### GetPriorityOk
 
-`func (o *MX) GetPriorityOk() (*int32, bool)`
+`func (o *MX) GetPriorityOk() (*string, bool)`
 
 GetPriorityOk returns a tuple with the Priority field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPriority
 
-`func (o *MX) SetPriority(v int32)`
+`func (o *MX) SetPriority(v string)`
 
 SetPriority sets Priority field to given value.
 

--- a/api/v0/domeneshop/docs/MXAllOf.md
+++ b/api/v0/domeneshop/docs/MXAllOf.md
@@ -6,13 +6,13 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Type** | **string** |  | 
 **Data** | **string** | The target MX host. | 
-**Priority** | **int32** | MX record priority, also known as preference. Lower values are usually preferred first, but this is not guaranteed | 
+**Priority** | **string** | MX record priority, also known as preference. Lower values are usually preferred first, but this is not guaranteed | 
 
 ## Methods
 
 ### NewMXAllOf
 
-`func NewMXAllOf(type_ string, data string, priority int32, ) *MXAllOf`
+`func NewMXAllOf(type_ string, data string, priority string, ) *MXAllOf`
 
 NewMXAllOf instantiates a new MXAllOf object
 This constructor will assign default values to properties that have it defined,
@@ -69,20 +69,20 @@ SetData sets Data field to given value.
 
 ### GetPriority
 
-`func (o *MXAllOf) GetPriority() int32`
+`func (o *MXAllOf) GetPriority() string`
 
 GetPriority returns the Priority field if non-nil, zero value otherwise.
 
 ### GetPriorityOk
 
-`func (o *MXAllOf) GetPriorityOk() (*int32, bool)`
+`func (o *MXAllOf) GetPriorityOk() (*string, bool)`
 
 GetPriorityOk returns a tuple with the Priority field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPriority
 
-`func (o *MXAllOf) SetPriority(v int32)`
+`func (o *MXAllOf) SetPriority(v string)`
 
 SetPriority sets Priority field to given value.
 

--- a/api/v0/domeneshop/docs/SRV.md
+++ b/api/v0/domeneshop/docs/SRV.md
@@ -9,15 +9,15 @@ Name | Type | Description | Notes
 **Ttl** | Pointer to **int32** | TTL of DNS record in seconds. Must be a multiple of 60. | [optional] [default to 3600]
 **Type** | **string** |  | 
 **Data** | **string** | The target hostname | 
-**Priority** | **int32** | SRV record priority, also known as preference. Lower values are usually preferred first | 
-**Weight** | **int32** | SRV record weight. Relevant if multiple records have same preference | 
-**Port** | **int32** | SRV record port. The port where the service is found. | 
+**Priority** | **string** | SRV record priority, also known as preference. Lower values are usually preferred first | 
+**Weight** | **string** | SRV record weight. Relevant if multiple records have same preference | 
+**Port** | **string** | SRV record port. The port where the service is found. | 
 
 ## Methods
 
 ### NewSRV
 
-`func NewSRV(id int32, host string, type_ string, data string, priority int32, weight int32, port int32, ) *SRV`
+`func NewSRV(id int32, host string, type_ string, data string, priority string, weight string, port string, ) *SRV`
 
 NewSRV instantiates a new SRV object
 This constructor will assign default values to properties that have it defined,
@@ -139,60 +139,60 @@ SetData sets Data field to given value.
 
 ### GetPriority
 
-`func (o *SRV) GetPriority() int32`
+`func (o *SRV) GetPriority() string`
 
 GetPriority returns the Priority field if non-nil, zero value otherwise.
 
 ### GetPriorityOk
 
-`func (o *SRV) GetPriorityOk() (*int32, bool)`
+`func (o *SRV) GetPriorityOk() (*string, bool)`
 
 GetPriorityOk returns a tuple with the Priority field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPriority
 
-`func (o *SRV) SetPriority(v int32)`
+`func (o *SRV) SetPriority(v string)`
 
 SetPriority sets Priority field to given value.
 
 
 ### GetWeight
 
-`func (o *SRV) GetWeight() int32`
+`func (o *SRV) GetWeight() string`
 
 GetWeight returns the Weight field if non-nil, zero value otherwise.
 
 ### GetWeightOk
 
-`func (o *SRV) GetWeightOk() (*int32, bool)`
+`func (o *SRV) GetWeightOk() (*string, bool)`
 
 GetWeightOk returns a tuple with the Weight field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetWeight
 
-`func (o *SRV) SetWeight(v int32)`
+`func (o *SRV) SetWeight(v string)`
 
 SetWeight sets Weight field to given value.
 
 
 ### GetPort
 
-`func (o *SRV) GetPort() int32`
+`func (o *SRV) GetPort() string`
 
 GetPort returns the Port field if non-nil, zero value otherwise.
 
 ### GetPortOk
 
-`func (o *SRV) GetPortOk() (*int32, bool)`
+`func (o *SRV) GetPortOk() (*string, bool)`
 
 GetPortOk returns a tuple with the Port field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPort
 
-`func (o *SRV) SetPort(v int32)`
+`func (o *SRV) SetPort(v string)`
 
 SetPort sets Port field to given value.
 

--- a/api/v0/domeneshop/docs/SRVAllOf.md
+++ b/api/v0/domeneshop/docs/SRVAllOf.md
@@ -6,15 +6,15 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Type** | **string** |  | 
 **Data** | **string** | The target hostname | 
-**Priority** | **int32** | SRV record priority, also known as preference. Lower values are usually preferred first | 
-**Weight** | **int32** | SRV record weight. Relevant if multiple records have same preference | 
-**Port** | **int32** | SRV record port. The port where the service is found. | 
+**Priority** | **string** | SRV record priority, also known as preference. Lower values are usually preferred first | 
+**Weight** | **string** | SRV record weight. Relevant if multiple records have same preference | 
+**Port** | **string** | SRV record port. The port where the service is found. | 
 
 ## Methods
 
 ### NewSRVAllOf
 
-`func NewSRVAllOf(type_ string, data string, priority int32, weight int32, port int32, ) *SRVAllOf`
+`func NewSRVAllOf(type_ string, data string, priority string, weight string, port string, ) *SRVAllOf`
 
 NewSRVAllOf instantiates a new SRVAllOf object
 This constructor will assign default values to properties that have it defined,
@@ -71,60 +71,60 @@ SetData sets Data field to given value.
 
 ### GetPriority
 
-`func (o *SRVAllOf) GetPriority() int32`
+`func (o *SRVAllOf) GetPriority() string`
 
 GetPriority returns the Priority field if non-nil, zero value otherwise.
 
 ### GetPriorityOk
 
-`func (o *SRVAllOf) GetPriorityOk() (*int32, bool)`
+`func (o *SRVAllOf) GetPriorityOk() (*string, bool)`
 
 GetPriorityOk returns a tuple with the Priority field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPriority
 
-`func (o *SRVAllOf) SetPriority(v int32)`
+`func (o *SRVAllOf) SetPriority(v string)`
 
 SetPriority sets Priority field to given value.
 
 
 ### GetWeight
 
-`func (o *SRVAllOf) GetWeight() int32`
+`func (o *SRVAllOf) GetWeight() string`
 
 GetWeight returns the Weight field if non-nil, zero value otherwise.
 
 ### GetWeightOk
 
-`func (o *SRVAllOf) GetWeightOk() (*int32, bool)`
+`func (o *SRVAllOf) GetWeightOk() (*string, bool)`
 
 GetWeightOk returns a tuple with the Weight field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetWeight
 
-`func (o *SRVAllOf) SetWeight(v int32)`
+`func (o *SRVAllOf) SetWeight(v string)`
 
 SetWeight sets Weight field to given value.
 
 
 ### GetPort
 
-`func (o *SRVAllOf) GetPort() int32`
+`func (o *SRVAllOf) GetPort() string`
 
 GetPort returns the Port field if non-nil, zero value otherwise.
 
 ### GetPortOk
 
-`func (o *SRVAllOf) GetPortOk() (*int32, bool)`
+`func (o *SRVAllOf) GetPortOk() (*string, bool)`
 
 GetPortOk returns a tuple with the Port field if it's non-nil, zero value otherwise
 and a boolean to check if the value has been set.
 
 ### SetPort
 
-`func (o *SRVAllOf) SetPort(v int32)`
+`func (o *SRVAllOf) SetPort(v string)`
 
 SetPort sets Port field to given value.
 

--- a/api/v0/domeneshop/model_mx.go
+++ b/api/v0/domeneshop/model_mx.go
@@ -27,14 +27,14 @@ type MX struct {
 	// The target MX host.
 	Data string `json:"data"`
 	// MX record priority, also known as preference. Lower values are usually preferred first, but this is not guaranteed
-	Priority int32 `json:"priority"`
+	Priority string `json:"priority"`
 }
 
 // NewMX instantiates a new MX object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewMX(id int32, host string, type_ string, data string, priority int32, ) *MX {
+func NewMX(id int32, host string, type_ string, data string, priority string, ) *MX {
 	this := MX{}
 	this.Id = id
 	this.Host = host
@@ -185,9 +185,9 @@ func (o *MX) SetData(v string) {
 }
 
 // GetPriority returns the Priority field value
-func (o *MX) GetPriority() int32 {
+func (o *MX) GetPriority() string {
 	if o == nil  {
-		var ret int32
+		var ret string
 		return ret
 	}
 
@@ -196,7 +196,7 @@ func (o *MX) GetPriority() int32 {
 
 // GetPriorityOk returns a tuple with the Priority field value
 // and a boolean to check if the value has been set.
-func (o *MX) GetPriorityOk() (*int32, bool) {
+func (o *MX) GetPriorityOk() (*string, bool) {
 	if o == nil  {
 		return nil, false
 	}
@@ -204,7 +204,7 @@ func (o *MX) GetPriorityOk() (*int32, bool) {
 }
 
 // SetPriority sets field value
-func (o *MX) SetPriority(v int32) {
+func (o *MX) SetPriority(v string) {
 	o.Priority = v
 }
 

--- a/api/v0/domeneshop/model_mx_all_of.go
+++ b/api/v0/domeneshop/model_mx_all_of.go
@@ -21,14 +21,14 @@ type MXAllOf struct {
 	// The target MX host.
 	Data string `json:"data"`
 	// MX record priority, also known as preference. Lower values are usually preferred first, but this is not guaranteed
-	Priority int32 `json:"priority"`
+	Priority string `json:"priority"`
 }
 
 // NewMXAllOf instantiates a new MXAllOf object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewMXAllOf(type_ string, data string, priority int32, ) *MXAllOf {
+func NewMXAllOf(type_ string, data string, priority string, ) *MXAllOf {
 	this := MXAllOf{}
 	this.Type = type_
 	this.Data = data
@@ -93,9 +93,9 @@ func (o *MXAllOf) SetData(v string) {
 }
 
 // GetPriority returns the Priority field value
-func (o *MXAllOf) GetPriority() int32 {
+func (o *MXAllOf) GetPriority() string {
 	if o == nil  {
-		var ret int32
+		var ret string
 		return ret
 	}
 
@@ -104,7 +104,7 @@ func (o *MXAllOf) GetPriority() int32 {
 
 // GetPriorityOk returns a tuple with the Priority field value
 // and a boolean to check if the value has been set.
-func (o *MXAllOf) GetPriorityOk() (*int32, bool) {
+func (o *MXAllOf) GetPriorityOk() (*string, bool) {
 	if o == nil  {
 		return nil, false
 	}
@@ -112,7 +112,7 @@ func (o *MXAllOf) GetPriorityOk() (*int32, bool) {
 }
 
 // SetPriority sets field value
-func (o *MXAllOf) SetPriority(v int32) {
+func (o *MXAllOf) SetPriority(v string) {
 	o.Priority = v
 }
 

--- a/api/v0/domeneshop/model_srv.go
+++ b/api/v0/domeneshop/model_srv.go
@@ -27,18 +27,18 @@ type SRV struct {
 	// The target hostname
 	Data string `json:"data"`
 	// SRV record priority, also known as preference. Lower values are usually preferred first
-	Priority int32 `json:"priority"`
+	Priority string `json:"priority"`
 	// SRV record weight. Relevant if multiple records have same preference
-	Weight int32 `json:"weight"`
+	Weight string `json:"weight"`
 	// SRV record port. The port where the service is found.
-	Port int32 `json:"port"`
+	Port string `json:"port"`
 }
 
 // NewSRV instantiates a new SRV object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewSRV(id int32, host string, type_ string, data string, priority int32, weight int32, port int32, ) *SRV {
+func NewSRV(id int32, host string, type_ string, data string, priority string, weight string, port string, ) *SRV {
 	this := SRV{}
 	this.Id = id
 	this.Host = host
@@ -191,9 +191,9 @@ func (o *SRV) SetData(v string) {
 }
 
 // GetPriority returns the Priority field value
-func (o *SRV) GetPriority() int32 {
+func (o *SRV) GetPriority() string {
 	if o == nil  {
-		var ret int32
+		var ret string
 		return ret
 	}
 
@@ -202,7 +202,7 @@ func (o *SRV) GetPriority() int32 {
 
 // GetPriorityOk returns a tuple with the Priority field value
 // and a boolean to check if the value has been set.
-func (o *SRV) GetPriorityOk() (*int32, bool) {
+func (o *SRV) GetPriorityOk() (*string, bool) {
 	if o == nil  {
 		return nil, false
 	}
@@ -210,14 +210,14 @@ func (o *SRV) GetPriorityOk() (*int32, bool) {
 }
 
 // SetPriority sets field value
-func (o *SRV) SetPriority(v int32) {
+func (o *SRV) SetPriority(v string) {
 	o.Priority = v
 }
 
 // GetWeight returns the Weight field value
-func (o *SRV) GetWeight() int32 {
+func (o *SRV) GetWeight() string {
 	if o == nil  {
-		var ret int32
+		var ret string
 		return ret
 	}
 
@@ -226,7 +226,7 @@ func (o *SRV) GetWeight() int32 {
 
 // GetWeightOk returns a tuple with the Weight field value
 // and a boolean to check if the value has been set.
-func (o *SRV) GetWeightOk() (*int32, bool) {
+func (o *SRV) GetWeightOk() (*string, bool) {
 	if o == nil  {
 		return nil, false
 	}
@@ -234,14 +234,14 @@ func (o *SRV) GetWeightOk() (*int32, bool) {
 }
 
 // SetWeight sets field value
-func (o *SRV) SetWeight(v int32) {
+func (o *SRV) SetWeight(v string) {
 	o.Weight = v
 }
 
 // GetPort returns the Port field value
-func (o *SRV) GetPort() int32 {
+func (o *SRV) GetPort() string {
 	if o == nil  {
-		var ret int32
+		var ret string
 		return ret
 	}
 
@@ -250,7 +250,7 @@ func (o *SRV) GetPort() int32 {
 
 // GetPortOk returns a tuple with the Port field value
 // and a boolean to check if the value has been set.
-func (o *SRV) GetPortOk() (*int32, bool) {
+func (o *SRV) GetPortOk() (*string, bool) {
 	if o == nil  {
 		return nil, false
 	}
@@ -258,7 +258,7 @@ func (o *SRV) GetPortOk() (*int32, bool) {
 }
 
 // SetPort sets field value
-func (o *SRV) SetPort(v int32) {
+func (o *SRV) SetPort(v string) {
 	o.Port = v
 }
 

--- a/api/v0/domeneshop/model_srv_all_of.go
+++ b/api/v0/domeneshop/model_srv_all_of.go
@@ -21,18 +21,18 @@ type SRVAllOf struct {
 	// The target hostname
 	Data string `json:"data"`
 	// SRV record priority, also known as preference. Lower values are usually preferred first
-	Priority int32 `json:"priority"`
+	Priority string `json:"priority"`
 	// SRV record weight. Relevant if multiple records have same preference
-	Weight int32 `json:"weight"`
+	Weight string `json:"weight"`
 	// SRV record port. The port where the service is found.
-	Port int32 `json:"port"`
+	Port string `json:"port"`
 }
 
 // NewSRVAllOf instantiates a new SRVAllOf object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewSRVAllOf(type_ string, data string, priority int32, weight int32, port int32, ) *SRVAllOf {
+func NewSRVAllOf(type_ string, data string, priority string, weight string, port string, ) *SRVAllOf {
 	this := SRVAllOf{}
 	this.Type = type_
 	this.Data = data
@@ -99,9 +99,9 @@ func (o *SRVAllOf) SetData(v string) {
 }
 
 // GetPriority returns the Priority field value
-func (o *SRVAllOf) GetPriority() int32 {
+func (o *SRVAllOf) GetPriority() string {
 	if o == nil  {
-		var ret int32
+		var ret string
 		return ret
 	}
 
@@ -110,7 +110,7 @@ func (o *SRVAllOf) GetPriority() int32 {
 
 // GetPriorityOk returns a tuple with the Priority field value
 // and a boolean to check if the value has been set.
-func (o *SRVAllOf) GetPriorityOk() (*int32, bool) {
+func (o *SRVAllOf) GetPriorityOk() (*string, bool) {
 	if o == nil  {
 		return nil, false
 	}
@@ -118,14 +118,14 @@ func (o *SRVAllOf) GetPriorityOk() (*int32, bool) {
 }
 
 // SetPriority sets field value
-func (o *SRVAllOf) SetPriority(v int32) {
+func (o *SRVAllOf) SetPriority(v string) {
 	o.Priority = v
 }
 
 // GetWeight returns the Weight field value
-func (o *SRVAllOf) GetWeight() int32 {
+func (o *SRVAllOf) GetWeight() string {
 	if o == nil  {
-		var ret int32
+		var ret string
 		return ret
 	}
 
@@ -134,7 +134,7 @@ func (o *SRVAllOf) GetWeight() int32 {
 
 // GetWeightOk returns a tuple with the Weight field value
 // and a boolean to check if the value has been set.
-func (o *SRVAllOf) GetWeightOk() (*int32, bool) {
+func (o *SRVAllOf) GetWeightOk() (*string, bool) {
 	if o == nil  {
 		return nil, false
 	}
@@ -142,14 +142,14 @@ func (o *SRVAllOf) GetWeightOk() (*int32, bool) {
 }
 
 // SetWeight sets field value
-func (o *SRVAllOf) SetWeight(v int32) {
+func (o *SRVAllOf) SetWeight(v string) {
 	o.Weight = v
 }
 
 // GetPort returns the Port field value
-func (o *SRVAllOf) GetPort() int32 {
+func (o *SRVAllOf) GetPort() string {
 	if o == nil  {
-		var ret int32
+		var ret string
 		return ret
 	}
 
@@ -158,7 +158,7 @@ func (o *SRVAllOf) GetPort() int32 {
 
 // GetPortOk returns a tuple with the Port field value
 // and a boolean to check if the value has been set.
-func (o *SRVAllOf) GetPortOk() (*int32, bool) {
+func (o *SRVAllOf) GetPortOk() (*string, bool) {
 	if o == nil  {
 		return nil, false
 	}
@@ -166,7 +166,7 @@ func (o *SRVAllOf) GetPortOk() (*int32, bool) {
 }
 
 // SetPort sets field value
-func (o *SRVAllOf) SetPort(v int32) {
+func (o *SRVAllOf) SetPort(v string) {
 	o.Port = v
 }
 


### PR DESCRIPTION
Example:

```http
-----------------------------------------------------
2021/01/09 14:53:53 [DEBUG] Domeneshop API Request Details:
---[ REQUEST ]---------------------------------------
GET /v0/domains/603701/dns/3439225 HTTP/1.1
Host: api.domeneshop.no
User-Agent: Terraform/0.14.3 (+https://www.terraform.io) Terraform-Plugin-SDK/2.2.0 terraform-provider-domeneshop/dev
Accept: application/json
Accept-Encoding: gzip


-----------------------------------------------------
2021/01/09 14:53:54 [DEBUG] Domeneshop API Response Details:
---[ RESPONSE ]--------------------------------------
HTTP/1.1 200 OK
Connection: close
Transfer-Encoding: chunked
Content-Type: application/json
Date: Sat, 09 Jan 2021 13:53:56 GMT
Server: nginx

{
 "data": "test-6061649332903295035.example.com.",
 "host": "test-6061649332903295035",
 "id": 3439225,
 "port": "5060",
 "priority": "10",
 "ttl": 300,
 "type": "SRV",
 "weight": "60"
}
```